### PR TITLE
Switch ContainerSSH license to Apache-2.0/CC-BY-4.0

### DIFF
--- a/wg-decisions/proposals/switch-license.md
+++ b/wg-decisions/proposals/switch-license.md
@@ -1,0 +1,12 @@
+# Switch ContainerSSH license to Apache-2.0/CC-BY-4.0
+
+The IP policy of the CNCF requires projects to use the Apache-2.0 license for code and the Creative Commons Attribution 4.0 International License for documentation. Therefore, we should switch the ContainerSSH license to these licenses in anticipation of (hopefully) getting accepted for CNCF sandboxing.
+
+## Benefits
+
+- Easier adoption to CNCF.
+- Legal safety around trademarks and patents.
+
+## Drawbacks
+
+- The code is no longer "free to copy-paste", you need to observe the license.


### PR DESCRIPTION
# Switch ContainerSSH license to Apache-2.0/CC-BY-4.0

The IP policy of the CNCF requires projects to use the Apache-2.0 license for code and the Creative Commons Attribution 4.0 International License for documentation. Therefore, we should switch the ContainerSSH license to these licenses in anticipation of (hopefully) getting accepted for CNCF sandboxing.

## Benefits

- Easier adoption to CNCF.
- Legal safety around trademarks and patents.

## Drawbacks

- The code is no longer "free to copy-paste", you need to observe the license.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).